### PR TITLE
respect required signers in the transaction body

### DIFF
--- a/src/components/transaction.tsx
+++ b/src/components/transaction.tsx
@@ -677,6 +677,12 @@ const TransactionViewer: FC<{
       const keyHash = address && cardano.parseAddress(address).payment_cred()?.to_keyhash()?.to_hex()
       keyHash && keyHashes.add(keyHash)
     })
+    const requiredSigners = transaction.body().required_signers()
+    if (requiredSigners) {
+      Array.from(toIter(requiredSigners))
+        .map(toHex)
+        .forEach(keyHashes.add.bind(keyHashes));
+    }
     setRequiredPaymentKeys(keyHashes)
   }, [cardano, txInputs, txInputsRegistry, setRequiredPaymentKeys])
   const txOutputs: Recipient[] = useMemo(() => getRecipientsFromCMLTransactionOutputs(txBody.outputs()), [txBody])


### PR DESCRIPTION
Previously, when a transaction that includes required signers in the body but doesn't necessarily include them in the inputs is being reviewed, the frontend doesn't acknowledge these.

Now, they are treated like any other required signature.